### PR TITLE
Automate maintainer-approval flag & Improve cat/port detection

### DIFF
--- a/extensions/BFBSD/lib/Helpers.pm
+++ b/extensions/BFBSD/lib/Helpers.pm
@@ -9,16 +9,25 @@ use base qw(Exporter);
 our @EXPORT = qw(
     no_maintainer get_user ports_product ports_component
     switch_to_automation
+    get_maintainers_of_bug _get_maintainer
 
     UID_AUTOMATION
     PRODUCT_PORTS
     COMPONENT_PORTS
+    PORTSDIR
+    INDEX
+    PORT_CAT_LIST
 );
 
 use constant {
     UID_AUTOMATION => "bugzilla\@FreeBSD.org",
     PRODUCT_PORTS => "Ports & Packages",
-    COMPONENT_PORTS => "Individual Port(s)"
+    COMPONENT_PORTS => "Individual Port(s)",
+
+#XXX Mokhi added inorder to avoid duplicated codes :)
+    PORTSDIR => "/usr/ports-dev",
+    INDEX => "INDEX",
+    PORT_CAT_LIST => "accessibility|arabic|archivers|astro|audio|benchmarks|biology|cad|chinese|comms|converters|databases|deskutils|devel|distfiles|dns|editors|emulators|finance|french|ftp|games|german|graphics|hebrew|hungarian|irc|japanese|java|korean|lang|mail|math|misc|multimedia|net|net\-im|net\-mgmt|net\-p2p|news|packages|palm|polish|ports\-mgmt|portuguese|print|russian|science|security|shells|sysutils|textproc|ukrainian|vietnamese|www|x11|x11\-clocks|x11\-drivers|x11\-fm|x11\-fonts|x11\-servers|x11\-themes|x11\-toolkits|x11\-wm",
 };
 
 sub ports_product {
@@ -65,5 +74,77 @@ sub switch_to_automation {
     Bugzilla->set_user(new Bugzilla::User($autoid));
     return $curuser;
 };
+
+#XXX Mokhi added inorder to avoid duplicated codes :)
+sub get_maintainers_of_bug {
+	my ($bug) = @_;
+
+	my @foundports = ();
+
+	# Is it a port in summary matching ([A-Za-z0-9_-]/[A-Za-z0-9_-])?
+	#my @res = ($bug->short_desc =~ /(?:^|[:\[\s+])([\w-]+\/[\w-\.]+)(?:[:\]\s+]|$)/g);
+	my @res = ($bug->short_desc =~ /(?:^|\W)((${\(PORT_CAT_LIST)})\/([\w\-\+](\.(?=\w))*)+)(?:$|\b)*/g);
+	if (@res && scalar(@res) > 0) {
+		# warn("Found ports in summary: @res");
+		push(@foundports, @res);
+	}
+
+	if (scalar(@foundports) == 0) {
+		# Did not find a port in subject
+		# Is it a port in the description matching
+		#  ([A-Za-z0-9_-]/[A-Za-z0-9_-])?
+		my $first = $bug->comments->[0]->body;
+		#@res = ($first =~ /(?:^|[:,\s+])([\w-]+\/[\w-\.]+)(?:[:,\s+]|$)/g);
+		@res = ($first =~ /(?:^|\W)((${\(PORT_CAT_LIST)})\/([\w\-\+](\.(?=\w))*)+)(?:$|\b)*/g);
+		if (@res && scalar(@res) > 0) {
+			# warn("Found ports in description: @res");
+			push(@foundports, @res);
+		}
+	}
+	# Remove duplicate entries.
+	my %hashed = map{$_, 1} @foundports;
+	@foundports = keys(%hashed);
+
+	# Add the maintainers of the affected ports to the CC. If there is
+	# only one person, add a feedback request for that person and
+	# optionally assign (if it is a committer), otherwise set all into
+	# CC.
+
+	my @maintainers = ();
+	foreach my $port (@foundports) {
+		my $maintainer = _get_maintainer($port);
+		if ($maintainer) {
+			push(@maintainers, $maintainer);
+		}
+	}
+
+	# Remove duplicate entries
+	%hashed = map{$_, 1} @maintainers;
+	@maintainers = keys(%hashed);
+
+	return @maintainers;
+}
+
+#XXX Mokhi added inorder to avoid duplicated codes :)
+sub _get_maintainer {
+	# we expect _get_maintainer("category/port")
+	my $port = shift();
+	my $portdir = "" . PORTSDIR . "/$port";
+	# Does it exist and is a directory?
+	if (-d $portdir) {
+		# temporarily manipulate path to allow the exec
+		# to access all necessary tools
+		my $oldenv = $ENV{PATH};
+		$ENV{PATH} .= "/usr/bin:/usr/local/bin:/usr/local/sbin";
+		my $maintainer = `PORTSDIR=@{[PORTSDIR]} make -C $portdir -V MAINTAINER`;
+		$ENV{PATH} = $oldenv;
+		chomp($maintainer);
+		return $maintainer;
+	} else {
+		warn("Port directory $portdir not found");
+	}
+	return;
+}
+
 
 1;

--- a/extensions/FBSDAttachments/Config.pm
+++ b/extensions/FBSDAttachments/Config.pm
@@ -1,0 +1,12 @@
+package Bugzilla::Extension::FBSDAttachments;
+use strict;
+
+use constant NAME => 'FBSDAttachments';
+
+use constant REQUIRED_MODULES => [
+];
+
+use constant OPTIONAL_MODULES => [
+];
+
+__PACKAGE__->NAME;

--- a/extensions/FBSDAttachments/Extension.pm
+++ b/extensions/FBSDAttachments/Extension.pm
@@ -1,0 +1,59 @@
+package Bugzilla::Extension::FBSDAttachments;
+
+use strict;
+use warnings;
+
+use base qw(Bugzilla::Extension);
+
+use Bugzilla::Comment;
+use Bugzilla::Field;
+use Bugzilla::FlagType;
+use Bugzilla::Flag;
+use Bugzilla::Mailer;
+use Bugzilla::User;
+use Bugzilla::Attachment;
+
+use Bugzilla::Extension::BFBSD::Helpers;
+
+our $VERSION = '0.3.0';
+
+sub attachment_process_data {
+	my ($self, $args) = @_;
+	my $data = $args->{'data'}; # XXX Maybe not needed
+	my $attrs = $args->{'attributes'};
+	my $dbh = Bugzilla->dbh; # XXX Maybe not needed
+
+	my $bug = $attrs->{'bug'};
+	my $attacher = Bugzilla->user;
+	my $is_patch = $attrs->{'ispatch'};
+
+	# We only add CCs, if it is a individual port bug
+	return if ( (!defined($bug) || !defined($attacher)) || ($bug->product ne PRODUCT_PORTS || $bug->component ne COMPONENT_PORTS) );
+
+	my @maintainers = get_maintainers_of_bug($bug);
+
+	if (defined($is_patch) && $is_patch) {
+		my $flag_approval;
+		my $flagtypes = Bugzilla::FlagType::match( { name => 'maintainer-approval' } );
+		if (scalar(@$flagtypes) == 1) {
+			$flag_approval = @{$flagtypes}[0];
+		}
+		if (!$flag_approval) {
+			warn("maintainer-approval flag not found");
+		} else {
+			my (@oldflags, @newflags);
+
+			#XXX maybe "$_->id == $attacher->id" is better for cmp
+			if (grep($_ == $attacher->login, @maintainers)) {
+				push(@newflags, { type_id   => $flag_approval->id, status	=> "+", requestee => $attacher->login });
+				$bug->set_flags(\@oldflags, \@newflags);
+			} else {
+				push(@newflags, { type_id   => $flag_approval->id, status	=> "?", requestee => @maintainers });
+				$bug->set_flags(\@oldflags, \@newflags);
+			}
+		}
+	}
+
+}
+
+__PACKAGE__->NAME;

--- a/extensions/FBSDAutoAssign/Extension.pm
+++ b/extensions/FBSDAutoAssign/Extension.pm
@@ -70,7 +70,8 @@ sub bug_end_of_create {
     my @foundports = ();
 
     # Is it a port patch in summary matching ([A-Za-z0-9_-]/[A-Za-z0-9_-])?
-    my @res = ($bug->short_desc =~ /(?:^|[:\[\s+])([\w\-]+\/[\w\-\.]+)(?:[:\]\s+]|$)/g);
+    #my @res = ($bug->short_desc =~ /(?:^|[:\[\s+])([\w-]+\/[\w-\.]+)(?:[:\]\s+]|$)/g);
+    my @res = ($bug->short_desc =~ /(?:^|\W)((${\(PORT_CAT_LIST)})\/([\w\-\+](\.(?=\w))*)+)(?:$|\b)*/g);
     if (@res && scalar(@res) > 0) {
         # warn("Found ports in summary: @res");
         push(@foundports, @res);
@@ -81,7 +82,8 @@ sub bug_end_of_create {
         # Is it a port in the description matching
         #  ([A-Za-z0-9_-]/[A-Za-z0-9_-])?
         my $first = $bug->comments->[0]->body;
-        @res = ($first =~ /(?:^|[:,\s+])([\w\-]+\/[\w\-\.]+)(?:[:,\s+]|$)/g);
+        #@res = ($first =~ /(?:^|[:,\s+])([\w-]+\/[\w-\.]+)(?:[:,\s+]|$)/g);
+        @res = ($first =~ /(?:^|\W)((${\(PORT_CAT_LIST)})\/([\w\-\+](\.(?=\w))*)+)(?:$|\b)*/g);
         if (@res && scalar(@res) > 0) {
             # warn("Found ports in description: @res");
             push(@foundports, @res);
@@ -102,7 +104,7 @@ sub bug_end_of_create {
         my $maintainer = _get_maintainer($port);
         if ($maintainer) {
             push(@maintainers, $maintainer);
-            push(@categories, $port =~ /^([\w\-]+)\/[\w\-\.]+$/g);
+            push(@categories, $port =~ /^([\w-]+)\/[\w-\.]+$/g);
         }
     }
 


### PR DESCRIPTION
modified:   extensions/BFBSD/lib/Helpers.pm
- added some constant values
  - from AA module to here for using in other modules [like FBSDAttachments:D]
  - a value for listing all categories (in order to be used in regexes)
- editted regexes to find "category/port" string in better way

new file:   extensions/FBSDAttachments/Config.pm
- Add config file for "FBSDAttachments" module

new file:   extensions/FBSDAttachments/Extension.pm
- FBSDAttachments automation module itself

modified:   extensions/FBSDAutoAssign/Extension.pm
- Improve regular expression to improve category/port detection (and fixing reported bugs)
- if we assume we know all category names we can change regex in a way to search for strings in form of (category name from our valid pool)/name of port in way of regex :D
  port names are strings in type of words(alphanumeric and _) and + and - and . but we know end of port name isn't '.' :)

This PR addresses:
- Bugzilla Issue: <link>https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198271</link>
- Bugzilla Issue: <link>https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=205735</link>
