### PR TITLE
Fix order of variables for generating doc links

### DIFF
--- a/extensions/SVNLinks/Extension.pm
+++ b/extensions/SVNLinks/Extension.pm
@@ -53,8 +53,8 @@ sub _link_base {
 }
 
 sub _link_doc {
-    my $rev = $1 || "";
-    my $pre = $2 || "";
+    my $pre = $1 || "";
+    my $rev = $2 || "";
     my $link = $pre . "<a href=\"" . SVN_DOC .
         "$rev\" title=\"revision $rev in doc\">doc r$rev</a>";
     return $link;


### PR DESCRIPTION
Refering to a revision in the FreeBSD doc branch inside a bug comment using "doc r12345" creates the wrong link because the second parameter (the revision number) of `_link_doc` is incorrectly assigned to `$pre` instead of `$rev`.
